### PR TITLE
Output error messages using Either

### DIFF
--- a/imagesize-conduit.cabal
+++ b/imagesize-conduit.cabal
@@ -23,6 +23,7 @@ Library
   Build-depends:       base                     >= 4            && < 5
                      , conduit                  >= 1.1          && < 1.3
                      , conduit-extra            >= 1.1          && < 1.2
+                     , exceptions               >= 0.4
                      , bytestring               >= 0.10
   ghc-options:     -Wall
 

--- a/test/main.hs
+++ b/test/main.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
-import qualified Data.Conduit as C
-import qualified Data.Conduit.Binary as CB
 import Control.Monad.Trans.Resource (runResourceT)
-import Data.Conduit.ImageSize
-
 import Test.Hspec
+import qualified Data.Conduit        as C
+import qualified Data.Conduit.Binary as CB
+
+import Data.Conduit.ImageSize
 
 main :: IO ()
 main = hspec $ do


### PR DESCRIPTION
We, at Silk, want a more refined fail report than `Nothing`. We decided to use `Either String`. Do you @snoyberg @meteficha agree with with this breaking change? Should I proceed and merge it on `master`?
